### PR TITLE
test(portfolio/app/(components)/sections

### DIFF
--- a/portfolio/app/(components)/sections/projectsSection/projectsSection.test.tsx
+++ b/portfolio/app/(components)/sections/projectsSection/projectsSection.test.tsx
@@ -10,6 +10,6 @@ describe("Projects Section", () => {
   test("Renders empty state when no projects", async () => {
     const ui = await ProjectsSection();
     render(ui);
-    expect(screen.getByTestId("projects-empty")).toBeDefined();
+    expect(screen.getByTestId("projects-empty")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This pull request makes a minor improvement to the test for the Projects Section component by updating an assertion to use a more appropriate matcher.

* Updated the test assertion to use `toBeInTheDocument()` instead of `toBeDefined()` when checking for the presence of the empty state element in the Projects Section tests.