### PR TITLE
Instructions improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ portfolio/
 
 ## Environment
 
-The app expects a base URL for the backend API.
+The app expects a base URL for the backend API. In the folder /data there's a file with the api operations there you will see the API_BASE_URL variable which contains either or the PUBLIC_DB | NEXT_PUBLIC_DB_CONNECTION variable that is set in the /config folder
 
 Example `.env` (in the `portfolio/` directory):
 
 ```
+
 PUBLIC_DB_CONNECTION=https://your-api.example.com
 # or (client-side only)
 # NEXT_PUBLIC_DB_CONNECTION=https://your-api.example.com


### PR DESCRIPTION
This pull request updates the documentation in the `portfolio/README.md` file to clarify how the app determines the base URL for the backend API. The explanation now references the `/data` and `/config` folders and describes how the `API_BASE_URL` variable is set.

Documentation improvements:

* Updated the environment setup instructions to specify that the API base URL is defined in a file within the `/data` folder, using either the `PUBLIC_DB` or `NEXT_PUBLIC_DB_CONNECTION` variable from the `/config` folder.