### PR TITLE
Style improvements in Section components

### DIFF
--- a/portfolio/app/(components)/layout/Section.tsx
+++ b/portfolio/app/(components)/layout/Section.tsx
@@ -8,6 +8,8 @@ export function Section({
   align = "left",
   noPadding,
   noMinHeight,
+  equalHeight,
+  customMinHeight,
 }: SectionProps) {
   const alignmentClasses = {
     left: "text-left",
@@ -16,7 +18,13 @@ export function Section({
   }[align];
 
   const paddingClasses = noPadding ? "px-0 py-0" : "px-6 py-20 sm:py-28";
-  const minHeightClass = noMinHeight ? "" : "min-h-[560px]";
+  const heightClass = noMinHeight
+    ? ""
+    : customMinHeight
+    ? customMinHeight
+    : "min-h-[560px]";
+
+  const flexClass = equalHeight ? "flex-1" : "";
 
   return (
     <>
@@ -24,9 +32,11 @@ export function Section({
         id={id}
         className={`w-full ${paddingClasses} ${className || ""}`}
       >
-        <div className={`mx-auto max-w-5xl flex flex-col ${minHeightClass}`}>
+        <div
+          className={`mx-auto max-w-5xl flex flex-col ${alignmentClasses} ${flexClass} ${heightClass}`}
+        >
           {title && (
-            <header className={`mb-10 ${alignmentClasses}`}>
+            <header className={`mb-10`}>
               <h2
                 className={`text-2xl sm:text-3xl font-semibold tracking-tight`}
               >

--- a/portfolio/app/(components)/layout/Section.tsx
+++ b/portfolio/app/(components)/layout/Section.tsx
@@ -33,12 +33,12 @@ export function Section({
         className={`w-full ${paddingClasses} ${className || ""}`}
       >
         <div
-          className={`mx-auto max-w-5xl flex flex-col ${alignmentClasses} ${flexClass} ${heightClass}`}
+          className={`mx-auto max-w-5xl flex flex-col ${flexClass} ${heightClass}`}
         >
           {title && (
             <header className={`mb-10`}>
               <h2
-                className={`text-2xl sm:text-3xl font-semibold tracking-tight`}
+                className={`${alignmentClasses} text-2xl sm:text-3xl font-semibold tracking-tight`}
               >
                 {title}
               </h2>

--- a/portfolio/app/(components)/sections/aboutSection/aboutSection.tsx
+++ b/portfolio/app/(components)/sections/aboutSection/aboutSection.tsx
@@ -1,7 +1,6 @@
 import { Section } from "@/app/(components)/layout/Section";
 import { getAboutMeInfo } from "@/data/dataApi";
 import { AboutInfo } from "@/types/types";
-import { publicEnv } from "@/config/env"; // ← import your front-end env
 
 export default async function AboutSection() {
   const aboutInfo = await getAboutMeInfo();
@@ -134,41 +133,6 @@ export default async function AboutSection() {
                       </li>
                     );
                   })}
-                </ul>
-              </div>
-            )}
-
-            {/* Documents */}
-            {(info.cvUrl || info.certificateUrl) && (
-              <div className="mt-6">
-                <h4 className="mb-1 font-semibold text-foreground/90">
-                  Documents:
-                </h4>
-                <ul className="flex flex-wrap items-center gap-4">
-                  {info.cvUrl && (
-                    <li>
-                      <a
-                        href={`${publicEnv.NEXT_PUBLIC_DB_CONNECTION}${info.cvUrl}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-indigo-500 hover:underline"
-                      >
-                        Download CV
-                      </a>
-                    </li>
-                  )}
-                  {info.certificateUrl && (
-                    <li>
-                      <a
-                        href={`${publicEnv.NEXT_PUBLIC_DB_CONNECTION}${info.certificateUrl}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-indigo-500 hover:underline"
-                      >
-                        View Certificate
-                      </a>
-                    </li>
-                  )}
                 </ul>
               </div>
             )}

--- a/portfolio/app/(components)/sections/aboutSection/aboutSection.tsx
+++ b/portfolio/app/(components)/sections/aboutSection/aboutSection.tsx
@@ -1,6 +1,7 @@
 import { Section } from "@/app/(components)/layout/Section";
 import { getAboutMeInfo } from "@/data/dataApi";
 import { AboutInfo } from "@/types/types";
+import { publicEnv } from "@/config/env"; // ← import your front-end env
 
 export default async function AboutSection() {
   const aboutInfo = await getAboutMeInfo();
@@ -133,6 +134,41 @@ export default async function AboutSection() {
                       </li>
                     );
                   })}
+                </ul>
+              </div>
+            )}
+
+            {/* Documents */}
+            {(info.cvUrl || info.certificateUrl) && (
+              <div className="mt-6">
+                <h4 className="mb-1 font-semibold text-foreground/90">
+                  Documents:
+                </h4>
+                <ul className="flex flex-wrap items-center gap-4">
+                  {info.cvUrl && (
+                    <li>
+                      <a
+                        href={`${publicEnv.NEXT_PUBLIC_DB_CONNECTION}${info.cvUrl}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-indigo-500 hover:underline"
+                      >
+                        Download CV
+                      </a>
+                    </li>
+                  )}
+                  {info.certificateUrl && (
+                    <li>
+                      <a
+                        href={`${publicEnv.NEXT_PUBLIC_DB_CONNECTION}${info.certificateUrl}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-indigo-500 hover:underline"
+                      >
+                        View Certificate
+                      </a>
+                    </li>
+                  )}
                 </ul>
               </div>
             )}

--- a/portfolio/app/(components)/sections/aboutSection/aboutSection.tsx
+++ b/portfolio/app/(components)/sections/aboutSection/aboutSection.tsx
@@ -10,7 +10,7 @@ export default async function AboutSection() {
     Array.isArray(aboutInfo) && aboutInfo.length > 0 ? aboutInfo : [];
 
   return (
-    <Section id="about" title="About Me" align="center">
+    <Section id="about" title="About Me" equalHeight>
       <div className="grid gap-6">
         {items.map((info) => (
           <div

--- a/portfolio/app/(components)/sections/aboutSection/aboutSection.tsx
+++ b/portfolio/app/(components)/sections/aboutSection/aboutSection.tsx
@@ -10,7 +10,7 @@ export default async function AboutSection() {
     Array.isArray(aboutInfo) && aboutInfo.length > 0 ? aboutInfo : [];
 
   return (
-    <Section id="about" title="About Me" equalHeight>
+    <Section id="about" title="About Me" equalHeight align="center">
       <div className="grid gap-6">
         {items.map((info) => (
           <div

--- a/portfolio/app/(components)/sections/contactSection/contactSection.tsx
+++ b/portfolio/app/(components)/sections/contactSection/contactSection.tsx
@@ -60,7 +60,7 @@ export default function ContactSection() {
   };
 
   return (
-    <Section id="contact" title="Contact Me" align="center">
+    <Section id="contact" title="Contact Me" equalHeight align="center">
       <div className="group relative mx-auto max-w-xl">
         <div
           className="

--- a/portfolio/app/(components)/sections/projectsSection/projectsSection.tsx
+++ b/portfolio/app/(components)/sections/projectsSection/projectsSection.tsx
@@ -7,7 +7,7 @@ export default async function ProjectsSection() {
   const projects: IProject[] = await getProjects();
 
   return (
-    <Section id="projects" title="Projects" align="center">
+    <Section id="projects" title="Projects" align="center" equalHeight>
       <div className="h-full w-full flex items-center justify-center py-10">
         {projects.length === 0 ? (
           <p

--- a/portfolio/i18n/dictionaries.ts
+++ b/portfolio/i18n/dictionaries.ts
@@ -4,7 +4,7 @@ export const dictionaries = {
   en: {
     hero: {
       title: "Behind Every Code, There's a Story",
-      subtitle: "Hi there! I'm David, a Full Stack Developer",
+      subtitle: "Welcome to David's Portfolio",
       buttons: {
         projects: "Projects",
         contact: "Contact",
@@ -15,7 +15,7 @@ export const dictionaries = {
   es: {
     hero: {
       title: "Tras Cada Línea de Código Hay una Historia",
-      subtitle: "Hola, soy David, Desarrollador Full Stack",
+      subtitle: "Bienvenido al Portafolio de David",
       buttons: {
         projects: "Proyectos",
         contact: "Contacto",

--- a/portfolio/types/types.ts
+++ b/portfolio/types/types.ts
@@ -38,8 +38,10 @@ export interface AboutInfo {
   skills: string[];
   techStack: TechStackItem[];
   experience?: { title: string; company: string; duration: string }[];
-  education: EducationItem[];
+  education?: EducationItem[];
   certifications?: { title: string; issuer: string; date: string }[];
+  cvUrl?: string;
+  cerficateUrl?: string;
   socialLinks: SocialLink[];
 }
 

--- a/portfolio/types/types.ts
+++ b/portfolio/types/types.ts
@@ -41,7 +41,7 @@ export interface AboutInfo {
   education?: EducationItem[];
   certifications?: { title: string; issuer: string; date: string }[];
   cvUrl?: string;
-  cerficateUrl?: string;
+  certificateUrl?: string;
   socialLinks: SocialLink[];
 }
 

--- a/portfolio/types/types.ts
+++ b/portfolio/types/types.ts
@@ -10,6 +10,8 @@ export type SectionProps = {
   children: React.ReactNode;
   noPadding?: boolean;
   noMinHeight?: boolean;
+  equalHeight?: boolean;
+  customMinHeight?: string;
 };
 
 export interface SocialLink {


### PR DESCRIPTION
This pull request enhances the flexibility and consistency of the `Section` layout component, updates portfolio section props and types, and improves the hero subtitle text in both English and Spanish. The most important changes are grouped below by theme.

**Section Layout Improvements:**

* Added `equalHeight` and `customMinHeight` props to the `Section` component, allowing sections to have equal height or a custom minimum height for better layout control. The component's internal class logic was updated accordingly. (`portfolio/app/(components)/layout/Section.tsx`, `portfolio/types/types.ts`) [[1]](diffhunk://#diff-4f4714fc1096438b1cc40109a3653a52872ca2e375a00dbaefdbf26f27e78afbR11-R12) [[2]](diffhunk://#diff-4f4714fc1096438b1cc40109a3653a52872ca2e375a00dbaefdbf26f27e78afbL19-R41) [[3]](diffhunk://#diff-f9194aaf333cf18fc125213d262c29b0d5ff6256b527fa8b9c505234b493938bR13-R14)
* Updated `AboutSection`, `ContactSection`, and `ProjectsSection` components to use the new `equalHeight` prop, ensuring consistent vertical sizing across main sections. (`portfolio/app/(components)/sections/aboutSection/aboutSection.tsx`, `portfolio/app/(components)/sections/contactSection/contactSection.tsx`, `portfolio/app/(components)/sections/projectsSection/projectsSection.tsx`) [[1]](diffhunk://#diff-661ea0c2838d2382cf9a46e1a78a10128c6d98394a55250de2c58cec02d5ea6cL12-R12) [[2]](diffhunk://#diff-03586859547a02629cf18a812c2d7147e2a7cdf11b8a9279a84126260aa547d2L63-R63) [[3]](diffhunk://#diff-795efe843cc5634a9fba29ee6b3c7e072b0a3eef58120d96a5b38148b1ced7eeL10-R10)

**Type and Data Model Updates:**

* Made the `education` field optional and added optional `cvUrl` and `certificateUrl` fields to the `AboutInfo` interface for greater flexibility in representing user data. (`portfolio/types/types.ts`)

**Content and Localization:**

* Updated the hero subtitle text in both English and Spanish to a more generic portfolio welcome message. (`portfolio/i18n/dictionaries.ts`) [[1]](diffhunk://#diff-ad557f03322d6bade348ca6b60cd2722aa31c1405fcb7f5e38026186a46fe6dfL7-R7) [[2]](diffhunk://#diff-ad557f03322d6bade348ca6b60cd2722aa31c1405fcb7f5e38026186a46fe6dfL18-R18)